### PR TITLE
Add GNOME 43 Support

### DIFF
--- a/activate_gnome@isjerryxiao/metadata.json
+++ b/activate_gnome@isjerryxiao/metadata.json
@@ -6,7 +6,8 @@
     "shell-version": [
         "40",
         "41",
-        "42"
+        "42",
+        "43"
     ],
     "version": 7,
     "url": "https://github.com/isjerryxiao/gnome-shell-extension-activate-gnome"


### PR DESCRIPTION
The extension works fine on GNOME 43 and there are no breaking changes for the extension seen here: https://gjs.guide/extensions/upgrading/gnome-shell-43.html