### PR TITLE
Make more visible on white backgrounds

### DIFF
--- a/activate_gnome@isjerryxiao/stylesheet.css
+++ b/activate_gnome@isjerryxiao/stylesheet.css
@@ -2,12 +2,10 @@
 .label-1 {
     font-weight: normal;
     color: rgba(255, 255, 255, 1);
-    background-color: rgba(0, 0, 0, 0);
-    border-radius: 5px;
+    text-shadow: 0 0 2px #000;
 }
 .label-2 {
     font-weight: normal;
     color: rgba(255, 255, 255, 1);
-    background-color: rgba(0, 0, 0, 0);
-    border-radius: 5px;
+    text-shadow: 0 0 2px #000;
 }


### PR DESCRIPTION
this didn't seem to do anything on my Gnome
```css
    background-color: rgba(0, 0, 0, 0);
    border-radius: 5px;
```
but these proposed changes look like this:
![image](https://github.com/user-attachments/assets/04f3d1bb-6a3a-4394-b776-1a30ff2208df)
